### PR TITLE
fix: CI image labels + h11/wheel CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN curl -sSL https://install.python-poetry.org | POETRY_HOME=/opt/poetry python
 
 COPY ./pyproject.toml ./poetry.lock* /app/
 
-RUN poetry lock && poetry install --no-root
+RUN poetry lock && poetry install --no-root && \
+    # Patch build tooling shipped in the image (CVE-2026-24049 in wheel, etc.).
+    pip install --no-cache-dir --upgrade pip setuptools wheel
 
 COPY ./alembic.ini /app
 COPY ./alembic/ /app/alembic/
@@ -35,5 +37,17 @@ RUN chmod +x /app/entrypoint.sh
 # Set via --build-arg APP_VERSION=... in CI; defaults to "dev" for local builds.
 ARG APP_VERSION=dev
 ENV APP_VERSION=${APP_VERSION}
+
+# Build metadata labels. The benefex/docker orb passes these build args and then
+# locates the pushed image to capture its digest via
+#   docker images -f "label=io.benefexapps.commit-id=<sha>"
+# so the commit-id label is required for the deploy step (otherwise docker-url
+# is empty and the build fails).
+ARG BUILD_DATE
+ARG BUILD_URL
+ARG COMMIT_ID
+LABEL io.benefexapps.build-date=$BUILD_DATE
+LABEL io.benefexapps.build-url=$BUILD_URL
+LABEL io.benefexapps.commit-id=$COMMIT_ID
 
 CMD ["/app/entrypoint.sh"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "aiofiles"
-version = "23.2.1"
+version = "24.1.0"
 description = "File support for asyncio."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "aiofiles-23.2.1-py3-none-any.whl", hash = "sha256:19297512c647d4b27a2cf7c34caa7e405c0d60b5560618a29a9fe027b18b0107"},
-    {file = "aiofiles-23.2.1.tar.gz", hash = "sha256:84ec2218d8419404abcb9f0c02df3f34c6e0a68ed41072acfb1cef5cbc29051a"},
+    {file = "aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5"},
+    {file = "aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c"},
 ]
 
 [[package]]
@@ -164,17 +164,17 @@ speedups = ["Brotli (>=1.2)", "aiodns (>=3.3.0)", "backports.zstd", "brotlicffi 
 
 [[package]]
 name = "aiohttp-socks"
-version = "0.8.4"
+version = "0.11.0"
 description = "Proxy connector for aiohttp"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8.0"
 files = [
-    {file = "aiohttp_socks-0.8.4-py3-none-any.whl", hash = "sha256:74b21105634ed31d56ed6fee43701ca16218b53475e606d56950a4d17e8290ea"},
-    {file = "aiohttp_socks-0.8.4.tar.gz", hash = "sha256:6b611d4ce838e9cf2c2fed5e0dba447cc84824a6cba95dc5747606201da46cb4"},
+    {file = "aiohttp_socks-0.11.0-py3-none-any.whl", hash = "sha256:9aacce57c931b8fbf8f6d333cf3cafe4c35b971b35430309e167a35a8aab9ec1"},
+    {file = "aiohttp_socks-0.11.0.tar.gz", hash = "sha256:0afe51638527c79077e4bd6e57052c87c4824233d6e20bb061c53766421b10f0"},
 ]
 
 [package.dependencies]
-aiohttp = ">=2.3.2"
+aiohttp = ">=3.10.0"
 python-socks = {version = ">=2.4.3,<3.0.0", extras = ["asyncio"]}
 
 [[package]]
@@ -1114,13 +1114,13 @@ test = ["objgraph", "psutil", "setuptools"]
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
@@ -1151,18 +1151,18 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.8"
+version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.8-py3-none-any.whl", hash = "sha256:5254cf149bcb5f75e9d1b2b9f729ea4a4b883d1ad7379fc632b727cec23674be"},
-    {file = "httpcore-1.0.8.tar.gz", hash = "sha256:86e94505ed24ea06514883fd44d2bc02d90e77e7979c8eb71b90f41d364a1bad"},
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
 ]
 
 [package.dependencies]
 certifi = "*"
-h11 = ">=0.13,<0.15"
+h11 = ">=0.16"
 
 [package.extras]
 asyncio = ["anyio (>=4.0,<5.0)"]
@@ -1412,27 +1412,29 @@ files = [
 
 [[package]]
 name = "matrix-nio"
-version = "0.24.0"
+version = "0.25.2"
 description = "A Python Matrix client library, designed according to sans I/O principles."
 optional = false
-python-versions = ">=3.8.0,<4.0.0"
+python-versions = ">=3.8.0"
 files = [
-    {file = "matrix_nio-0.24.0-py3-none-any.whl", hash = "sha256:87bcf8139e081e8e85ced2d02a2be08662bf1accb726e850325b4ab3c840e946"},
-    {file = "matrix_nio-0.24.0.tar.gz", hash = "sha256:75f9c58958dbe353bec29be1854835df6d91e6f3be2952261a3a27c99ea896b9"},
+    {file = "matrix_nio-0.25.2-py3-none-any.whl", hash = "sha256:9c2880004b0e475db874456c0f79b7dd2b6285073a7663bcaca29e0754a67495"},
+    {file = "matrix_nio-0.25.2.tar.gz", hash = "sha256:8ef8180c374e12368e5c83a692abfb3bab8d71efcd17c5560b5c40c9b6f2f600"},
 ]
 
 [package.dependencies]
-aiofiles = ">=23.1.0,<24.0.0"
-aiohttp = ">=3.9.0,<4.0.0"
-aiohttp-socks = ">=0.8.4,<0.9.0"
-h11 = ">=0.14.0,<0.15.0"
-h2 = ">=4.0.0,<5.0.0"
-jsonschema = ">=4.14.0,<5.0.0"
-pycryptodome = ">=3.10.1,<4.0.0"
-unpaddedbase64 = ">=2.1.0,<3.0.0"
+aiofiles = ">=24.1,<25.0"
+aiohttp = ">=3.10,<4.0"
+aiohttp-socks = ">=0.8,<1.0"
+h11 = ">=0.14,<1.0"
+h2 = ">=4.0,<5.0"
+jsonschema = ">=4.14,<5.0"
+pycryptodome = ">=3.10,<4.0"
+unpaddedbase64 = ">=2.1,<3.0"
 
 [package.extras]
-e2e = ["atomicwrites (>=1.4.0,<2.0.0)", "cachetools (>=4.2.1,<5.0.0)", "peewee (>=3.14.4,<4.0.0)", "python-olm (>=3.1.3,<4.0.0)"]
+dev = ["aioresponses (>=0.7,<1.0)", "faker (>=8.0,<9.0)", "hpack (>=4.0,<5.0)", "hyperframe (>=6.0,<7.0)", "hypothesis (>=6.8,<7.0)", "matrix-nio[e2e]", "mypy (>=1.11,<2.0)", "mypy-extensions (>=1.0,<2.0)", "pre-commit", "pytest (>=8.2,<9.0)", "pytest-aiohttp (>=0.3,<1.0)", "pytest-asyncio (>=0.24,<1.0)", "pytest-benchmark (>=4.0,<5.0)", "pytest-cov (>=2.11,<3.0)", "pytest-flake8 (>=1.2,<2.0)"]
+docs = ["matrix-nio[dev]", "setuptools (>=61.0)", "sphinx (>=7.4,<8.0)", "sphinx-autodoc-typehints (>=2.1,<3.0)", "sphinx-mdinclude (>=0.5)", "sphinx-rtd-theme (>=2.0,<3.0)"]
+e2e = ["atomicwrites (>=1.4,<2.0)", "cachetools (>=5.3,<6.0)", "peewee (>=3.14,<4.0)", "python-olm (>=3.2,<4.0)"]
 
 [[package]]
 name = "multidict"
@@ -3169,4 +3171,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.14.5"
-content-hash = "29bda08a6bc871b3151dae5c7393312153dc64cb948dc039e32828d7538dcdfc"
+content-hash = "49886be3b475bd01867ae343d6847191bb60366cc4da0d967eb1585882f575bf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,9 @@ pyjwt = "^2.10.1"
 python-dotenv = "^1.2.1"
 python-gitlab = {extras = ["graphql"], version = "^7.0.0"}
 requests = "^2.32.5"
-matrix-nio = "^0.24"
+matrix-nio = "^0.25"
+# Security floor: CVE-2025-43859 (h11 < 0.16.0). Transitive via httpcore/matrix-nio.
+h11 = ">=0.16.0"
 slack-bolt = "^1.27.0"
 slack-sdk = "^3.39.0"
 sqlmodel = "^0.0.28"


### PR DESCRIPTION
## Build failure fix
The `benefex/docker` orb captures the pushed image digest via
`docker images -f "label=io.benefexapps.commit-id=<sha>"`. Our Dockerfile never set
that label, so the filter matched nothing → `docker-url is empty` → deploy failed.
Added the `io.benefexapps.{build-date,build-url,commit-id}` labels (the orb already
passes these as build args).

## CVE fixes
- **CVE-2025-43859 (h11, critical)** — h11 `0.14.0 → 0.16.0`. It was capped `<0.15`
  by httpcore 1.0.8 and matrix-nio 0.24.0, so bumped `matrix-nio` to `^0.25` (0.25.2),
  which lets httpcore 1.0.9 + h11 0.16.0 resolve. Added an explicit `h11 >= 0.16.0` floor.
- **CVE-2026-24049 (wheel, high)** — `wheel` (+ setuptools/pip) upgraded as build
  tooling in the image (not project deps).

## Validation
- 318 tests pass with matrix-nio 0.25.2 + h11 0.16.0.
- Built the image locally and confirmed: the orb's label filter matches the image,
  and `h11=0.16.0`, `wheel=0.47.0` are installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)