### PR TITLE
feat: auto-join @odin bot to every incident channel

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -236,6 +236,8 @@ reminders:
 # Action types:
 #   invite_group    — invite a Slack user group into the incident channel
 #     name: slack-group-handle
+#   invite_user     — invite a single user or bot into the incident channel
+#     user: U0XXXXXXX  # Slack member/bot ID (not a display name)
 #   page_pagerduty  — trigger a PagerDuty escalation (requires PD integration)
 #     escalation_policy: POLICY_ID
 #     priority: high  # low (default) | high

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -84,7 +84,7 @@ incidentbot:
           trigger: on_open
           actions:
             - type: invite_user
-              user: REPLACE_WITH_ODIN_USER_ID
+              user: U0B60D43BA4
       integrations:
         zoom:
           enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,6 +77,14 @@ incidentbot:
           actions:
             - type: invite_group
               name: platform
+        # Auto-join the @odin bot to every incident channel on open.
+        # `user` must be Odin's Slack member ID (e.g. U0XXXXXXX / bot user ID),
+        # not its display name — find it via the bot's Slack profile.
+        - id: invite-odin
+          trigger: on_open
+          actions:
+            - type: invite_user
+              user: REPLACE_WITH_ODIN_USER_ID
       integrations:
         zoom:
           enabled: true

--- a/incidentbot/configuration/schema.py
+++ b/incidentbot/configuration/schema.py
@@ -76,8 +76,9 @@ class Reminder(BaseModel):
 
 
 class AutomationAction(BaseModel):
-    type: Literal["invite_group", "page_pagerduty", "post_message"]
+    type: Literal["invite_group", "invite_user", "page_pagerduty", "post_message"]
     name: str | None = None            # invite_group: group name
+    user: str | None = None            # invite_user: user/bot member ID
     escalation_policy: str | None = None  # page_pagerduty: policy ID
     priority: Literal["low", "high"] = "low"
     message: str | None = None         # post_message: text

--- a/incidentbot/incident/automations.py
+++ b/incidentbot/incident/automations.py
@@ -43,6 +43,8 @@ def _execute(action, record) -> None:
     match action.type:
         case "invite_group":
             _invite_group(action, record)
+        case "invite_user":
+            _invite_user(action, record)
         case "page_pagerduty":
             _page_pagerduty(action, record)
         case "post_message":
@@ -67,6 +69,23 @@ def _invite_group(action, record) -> None:
         )
     except Exception as error:
         logger.exception("automation invite_group failed", group=action.name, error=error)
+
+
+def _invite_user(action, record) -> None:
+    if not action.user:
+        logger.warning("automation invite_user: no user configured")
+        return
+    adapter = get_adapter()
+    try:
+        adapter.invite_user(room_id=record.channel_id, user_id=action.user)
+        EventLogHandler.create(
+            event=f"User {action.user} was invited via automation",
+            incident_id=record.id,
+            incident_slug=record.slug,
+            source="system",
+        )
+    except Exception as error:
+        logger.exception("automation invite_user failed", user=action.user, error=error)
 
 
 def _page_pagerduty(action, record) -> None:

--- a/tests/test_automations_execute.py
+++ b/tests/test_automations_execute.py
@@ -15,7 +15,7 @@ with (
     patch("sqlmodel.create_engine", return_value=MagicMock()),
     patch("slack_sdk.WebClient", return_value=MagicMock()),
 ):
-    from incidentbot.incident.automations import _execute, _invite_group, _page_pagerduty, _post_message
+    from incidentbot.incident.automations import _execute, _invite_group, _invite_user, _page_pagerduty, _post_message
 
 
 def _make_record(channel_id="C123", channel_name="inc-test", slug="inc-test", status="investigating"):
@@ -41,6 +41,13 @@ class TestExecuteDispatch:
         action = _make_action("invite_group", name="oncall")
         record = _make_record()
         with patch("incidentbot.incident.automations._invite_group") as mock_fn:
+            _execute(action, record)
+        mock_fn.assert_called_once_with(action, record)
+
+    def test_dispatches_invite_user(self):
+        action = _make_action("invite_user", user="U999")
+        record = _make_record()
+        with patch("incidentbot.incident.automations._invite_user") as mock_fn:
             _execute(action, record)
         mock_fn.assert_called_once_with(action, record)
 
@@ -110,6 +117,50 @@ class TestInviteGroup:
             _invite_group(action, record)
 
         mock_log.warning.assert_called_once()
+
+
+class TestInviteUser:
+    def test_invites_user_and_logs_event(self):
+        action = _make_action("invite_user", user="U999")
+        record = _make_record()
+        mock_adapter = MagicMock()
+
+        with (
+            patch("incidentbot.incident.automations.get_adapter", return_value=mock_adapter),
+            patch("incidentbot.incident.automations.EventLogHandler") as mock_log,
+        ):
+            _invite_user(action, record)
+
+        mock_adapter.invite_user.assert_called_once_with(room_id="C123", user_id="U999")
+        mock_log.create.assert_called_once()
+
+    def test_logs_warning_when_no_user_configured(self):
+        action = _make_action("invite_user", user=None)
+        record = _make_record()
+        mock_adapter = MagicMock()
+
+        with (
+            patch("incidentbot.incident.automations.get_adapter", return_value=mock_adapter),
+            patch("incidentbot.incident.automations.logger") as mock_log,
+        ):
+            _invite_user(action, record)
+
+        mock_log.warning.assert_called_once()
+        mock_adapter.invite_user.assert_not_called()
+
+    def test_logs_exception_on_failure(self):
+        action = _make_action("invite_user", user="U999")
+        record = _make_record()
+        mock_adapter = MagicMock()
+        mock_adapter.invite_user.side_effect = Exception("boom")
+
+        with (
+            patch("incidentbot.incident.automations.get_adapter", return_value=mock_adapter),
+            patch("incidentbot.incident.automations.logger") as mock_log,
+        ):
+            _invite_user(action, record)
+
+        mock_log.exception.assert_called_once()
 
 
 class TestPagePagerDuty:


### PR DESCRIPTION
## What

Auto-joins the **@odin** Slack bot to every incident channel when an incident is opened.

There was no config-only way to auto-invite a *single* user/bot — the existing `invite_group` automation only handles Slack **user groups**. This adds a sibling `invite_user` action and uses it via a standard `on_open` automation, exactly like the existing `invite-platform` group automation.

## Changes

- **`invite_user` automation action** (`schema.py`, `automations.py`) — invites one user/bot by Slack member ID into the incident channel and writes a timeline event, mirroring `_invite_group`. Logs a warning if no user is configured and an exception (non-fatal) if the invite fails.
- **helm values** — new `invite-odin` automation (`trigger: on_open`) alongside `invite-platform`.
- **`config.yaml.sample`** — documents the new action type.
- **tests** — dispatch + success/no-user/failure cases (full suite: 322 passed).


🤖 Generated with [Claude Code](https://claude.com/claude-code)