### PR TITLE
feat(jira): auto-create IM incident ticket on incident open

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -321,11 +321,15 @@ automations: []
     #   issue_types: [Bug, Task, Incident]
     #   labels: [incident]           # optional labels applied to created issues
     #   priorities: [High, Medium, Low]  # optional; surfaced in the Jira modal
-    #   status_mapping:              # maps incident statuses → Jira statuses
-    #     - investigating: In Progress
-    #     - identified: In Progress
-    #     - monitoring: In Review
-    #     - resolved: Done
+    #   status_mapping:              # maps incident statuses → Jira status names
+    #     - incident_status: investigating
+    #       jira_status: In Progress
+    #     - incident_status: identified
+    #       jira_status: In Progress
+    #     - incident_status: monitoring
+    #       jira_status: In Review
+    #     - incident_status: resolved
+    #       jira_status: Done
 
     # Statuspage (Atlassian) — manage a status page from incident channels
     # Requires env vars: STATUSPAGE_API_KEY, STATUSPAGE_PAGE_ID

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,6 +96,29 @@ incidentbot:
             parent: Incident Postmortems
             space: OneHub
             template_id: 1533083725
+          # Jira — auto-create an incident ticket in the IM project on open.
+          # Acts as the single hub to link any related issues to. Reuses the
+          # ATLASSIAN_API_URL/USERNAME/TOKEN secrets already used by Confluence.
+          jira:
+            enabled: true
+            auto_create_issue: true
+            auto_create_issue_type: Incident
+            project: IM
+            issue_types:
+              - Incident
+            labels:
+              - incident
+            # Maps incident-bot statuses to IM workflow status names so the
+            # ticket transitions as the incident progresses.
+            status_mapping:
+              - incident_status: investigating
+                jira_status: Investigating
+              - incident_status: identified
+                jira_status: Identified
+              - incident_status: monitoring
+                jira_status: Monitoring
+              - incident_status: resolved
+                jira_status: Resolved
           statuspage:
             enabled: true
             url: https://status.onehub.global/

--- a/incidentbot/incident/core.py
+++ b/incidentbot/incident/core.py
@@ -499,11 +499,40 @@ class Incident:
                 from incidentbot.models.database import JiraIssueRecord
 
                 try:
+                    # The IM ticket acts as the single hub for the incident, so
+                    # give it a useful body linking back to the Slack channel
+                    # and summarising the incident context.
+                    summary = record.description or record.channel_name
+                    description_lines = [
+                        record.description or "An incident has been declared.",
+                        "",
+                        f"Incident channel: {record.channel_name}",
+                    ]
+                    if record.link:
+                        description_lines.append(f"Slack channel: {record.link}")
+                    if record.severity:
+                        description_lines.append(
+                            f"Severity: {record.severity.upper()}"
+                        )
+                    if record.status:
+                        description_lines.append(f"Status: {record.status}")
+                    if record.meeting_link:
+                        description_lines.append(
+                            f"Meeting: {record.meeting_link}"
+                        )
+
+                    # Fall back to the first configured issue type if an explicit
+                    # auto-create type has not been set.
+                    issue_type = (
+                        settings.integrations.atlassian.jira.auto_create_issue_type
+                        or settings.integrations.atlassian.jira.issue_types[0]
+                    )
+
                     issue_obj = JiraIssue(
-                        description=record.channel_name,
+                        description="\n".join(description_lines),
                         incident_id=record.id,
-                        issue_type=settings.integrations.atlassian.jira.auto_create_issue_type,
-                        summary=record.description,
+                        issue_type=issue_type,
+                        summary=summary,
                     )
                     resp = issue_obj.new()
 
@@ -521,8 +550,8 @@ class Incident:
                             event_id = adapter.post_jira_issue(
                                 room_id=record.channel_id,
                                 key=resp.get("key"),
-                                summary=record.description,
-                                issue_type=settings.integrations.atlassian.jira.auto_create_issue_type,
+                                summary=summary,
+                                issue_type=issue_type,
                                 link=issue_link,
                             )
                             if event_id:


### PR DESCRIPTION
## What

Enables the Jira integration so an incident ticket is automatically created in the **IM** (Incident Management) Jira project whenever an incident is opened. This gives us a single hub to link any related issues to.

Example of the kind of ticket this produces: https://benefex.atlassian.net/browse/IM-1

## Background

The auto-create-Jira-issue capability already existed in `incidentbot/incident/core.py` but was never enabled or pointed at a project. This PR enables it and fixes two rough edges in the existing code path.

## Changes

- **`helm/values.yaml`** — add the `integrations.atlassian.jira` block (production config lives here; local `config.yaml` is gitignored):
  - Project `IM`, issue type `Incident`, `auto_create_issue: true`.
  - `status_mapping` wired to the actual IM workflow status names (Investigating / Identified / Monitoring / Resolved) so the ticket transitions as the incident progresses.
  - Reuses the `ATLASSIAN_API_URL/USERNAME/TOKEN` secrets already provisioned for Confluence — no new secrets required.
- **`incidentbot/incident/core.py`** — two fixes to the existing auto-create path:
  - Build a useful ticket body (incident summary, Slack channel link, severity, status, meeting link) instead of just the channel name, so the ticket is actually usable as the linking hub.
  - Fall back to `issue_types[0]` when `auto_create_issue_type` is unset (previously would send a null issue type and fail).
- **`config.yaml.sample`** — fix the documented `status_mapping` format. The sample's shorthand would crash `update_issue_status`; the code requires `incident_status`/`jira_status` keys.

## Verification

- Both the Helm and local Jira config blocks validate against the `JiraIntegration` schema.
- IM project inspected via Jira API: single issue type (`Incident`), workflow statuses map 1:1 to incident-bot statuses.
- `core.py` parses; existing message-builder tests pass (36/36).

## Notes

- The GitLab sample in `config.yaml.sample` has the same latent status_mapping shorthand bug — left out of scope but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)