### PR TITLE
feat(jira): set required IM custom fields on auto-created ticket

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -321,6 +321,19 @@ automations: []
     #   issue_types: [Bug, Task, Incident]
     #   labels: [incident]           # optional labels applied to created issues
     #   priorities: [High, Medium, Low]  # optional; surfaced in the Jira modal
+    #   custom_fields:               # optional; set extra/required fields on created issues
+    #     # Values support tokens: {slack_url} {channel_name} {slug}
+    #     # {incident_id} {severity} {summary} {status}
+    #     - id: customfield_10302    # a free-text field
+    #       type: string            # option | user | number | array_option | string (default)
+    #       value: "{slack_url}"
+    #     - id: customfield_10279    # a select/option field
+    #       type: option
+    #       value: "{severity}"
+    #       value_map:               # remap the resolved value -> the Jira option value
+    #         sev1: Sev-1
+    #         sev2: Sev-2
+    #         sev3: Sev-3
     #   status_mapping:              # maps incident statuses → Jira status names
     #     - incident_status: investigating
     #       jira_status: In Progress

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -108,6 +108,23 @@ incidentbot:
               - Incident
             labels:
               - incident
+            # Required custom fields on the IM "Incident" create screen.
+            # Values support tokens: {slack_url} {channel_name} {slug}
+            # {incident_id} {severity} {summary} {status}.
+            custom_fields:
+              - id: customfield_10302   # Slack
+                type: string
+                value: "{slack_url}"
+              - id: customfield_17841   # Incident Bot Ref
+                type: string
+                value: "{slug}"
+              - id: customfield_10279   # Severity
+                type: option
+                value: "{severity}"
+                value_map:
+                  sev1: Sev-1
+                  sev2: Sev-2
+                  sev3: Sev-3
             # Maps incident-bot statuses to IM workflow status names so the
             # ticket transitions as the incident progresses.
             status_mapping:

--- a/incidentbot/configuration/schema.py
+++ b/incidentbot/configuration/schema.py
@@ -137,6 +137,13 @@ class ConfluenceIntegration(BaseModel):
 class JiraIntegration(BaseModel):
     auto_create_issue: bool = False
     auto_create_issue_type: str | None = None
+    # Extra (often required) fields to set on created issues, e.g. custom
+    # fields specific to a project's create screen. Each entry:
+    #   id:        the field id (e.g. "customfield_10302")
+    #   type:      option | user | number | array_option | string (default)
+    #   value:     value, may contain tokens like "{slack_url}" / "{severity}"
+    #   value_map: optional dict mapping the resolved value -> final value
+    custom_fields: list[dict[str, Any]] | None = None
     enabled: bool = False
     issue_types: list[str]
     labels: list[str] | None = None

--- a/incidentbot/incident/core.py
+++ b/incidentbot/incident/core.py
@@ -528,11 +528,58 @@ class Incident:
                         or settings.integrations.atlassian.jira.issue_types[0]
                     )
 
+                    # Build any project-specific fields (e.g. required custom
+                    # fields on the create screen) from config. Values may
+                    # reference the tokens below and be remapped via value_map.
+                    tokens = {
+                        "slack_url": record.link or "",
+                        "channel_name": record.channel_name or "",
+                        "slug": record.slug or "",
+                        "incident_id": str(record.id),
+                        "severity": record.severity or "",
+                        "summary": summary,
+                        "status": record.status or "",
+                    }
+                    extra_fields = {}
+                    for cf in (
+                        settings.integrations.atlassian.jira.custom_fields or []
+                    ):
+                        field_id = cf.get("id")
+                        if not field_id:
+                            continue
+
+                        value = cf.get("value", "")
+                        if isinstance(value, str):
+                            try:
+                                value = value.format(**tokens)
+                            except (KeyError, IndexError, ValueError):
+                                pass
+
+                        value_map = cf.get("value_map")
+                        if value_map:
+                            value = value_map.get(value, value)
+
+                        field_type = cf.get("type", "string")
+                        if field_type == "option":
+                            extra_fields[field_id] = {"value": value}
+                        elif field_type == "array_option":
+                            extra_fields[field_id] = [{"value": value}]
+                        elif field_type == "user":
+                            extra_fields[field_id] = {"id": value}
+                        elif field_type == "number":
+                            try:
+                                extra_fields[field_id] = float(value)
+                            except (TypeError, ValueError):
+                                continue
+                        else:
+                            extra_fields[field_id] = value
+
                     issue_obj = JiraIssue(
                         description="\n".join(description_lines),
                         incident_id=record.id,
                         issue_type=issue_type,
                         summary=summary,
+                        fields=extra_fields,
                     )
                     resp = issue_obj.new()
 

--- a/incidentbot/jira/issue.py
+++ b/incidentbot/jira/issue.py
@@ -13,6 +13,7 @@ class JiraIssue:
         incident_id: int,
         issue_type: str,
         summary: str,
+        fields: dict | None = None,
     ):
         self.jira = JiraApi()
         self.incident_id = incident_id
@@ -22,10 +23,13 @@ class JiraIssue:
 
         self.description = description
         self.issue_type = issue_type
-        self.labels = settings.integrations.atlassian.jira.labels + [
+        self.labels = (settings.integrations.atlassian.jira.labels or []) + [
             self.incident_data.channel_name
         ]
         self.summary = summary
+        # Additional fields (e.g. project-specific required custom fields)
+        # merged into the create payload.
+        self.fields = fields or {}
 
     def new(self):
         """
@@ -40,6 +44,7 @@ class JiraIssue:
                     "labels": self.labels,
                     "project": {"id": self.jira.project_id},
                     "summary": self.summary,
+                    **self.fields,
                 }
             )
 


### PR DESCRIPTION
## What

Follow-up to the auto-create-IM-ticket feature. Jira was rejecting the auto-created ticket because the IM **Incident** issue type has three **required custom fields** that weren't being sent:

```
HTTPError('Slack is required.\nIncident Bot Ref is required.\nSeverity is required.')
```

This PR populates them via a configurable mechanism (no hardcoded field ids).

| Field | ID | Type |
|---|---|---|
| Slack | `customfield_10302` | string |
| Incident Bot Ref | `customfield_17841` | string |
| Severity | `customfield_10279` | option (Sev-0/1/2/3) |

## Changes

- **`schema.py`** — add `custom_fields` to `JiraIntegration`.
- **`jira/issue.py`** — `JiraIssue` accepts an optional `fields` dict merged into the create payload; guard `labels` against a null config value.
- **`incident/core.py`** — resolve each custom field's value from tokens (`{slack_url}` `{channel_name}` `{slug}` `{incident_id}` `{severity}` `{summary}` `{status}`), apply an optional `value_map` (e.g. `sev2` → `Sev-2`), and wrap by type (`option`/`user`/`number`/`array_option`/`string`).
- **`helm/values.yaml`** + **`config.yaml.sample`** — configure/document the IM custom fields.

## Verification

- Generated payload verified against the live IM create-metadata: `customfield_10279 = {"value": "Sev-2"}` is a valid Severity option; the two string fields resolve correctly.
- Both Helm and local Jira config blocks validate against the `JiraIntegration` schema.
- Full test suite passes (322 passed).

## Notes

- The **manual** "create Jira issue" Slack modal does not send these custom fields, so that path would still fail against IM — out of scope here (auto-create-on-open only).
- Unrelated: the `add_bookmark` `missing_scope: bookmarks:write` error at incident open is a Slack app scope that's declared in `manifest.yaml` but not yet granted to the deployed app — reinstall the app to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)